### PR TITLE
add `package.json` for `mip` install support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "urls": [
+      ["micropython_bmpxxx/__init__.py",    "github:bradcar/MicroPython_BMPxxx/micropython_bmpxxx/__init__.py"],
+      ["micropython_bmpxxx/bmpxxx.py",      "github:bradcar/MicroPython_BMPxxx/micropython_bmpxxx/bmpxxx.py"],
+      ["micropython_bmpxxx/i2c_helpers.py", "github:bradcar/MicroPython_BMPxxx/micropython_bmpxxx/i2c_helpers.py"]
+    ],
+    "deps": [
+    ],
+    "version": "0.0.1"
+}


### PR DESCRIPTION
Saw you were active recently and wanted to use a maintained lib for BME280. 

making this PR, the package json explicitly references source files in upstream repo so merging it should *just *work.

Example how to use in `mip` (target references my favored local install directory, default `./lib` ). 

```
import mip
mip.install("github:idcrook/MicroPython_BMPxxx", target="third-party")
```

output

```
Installing github:idcrook/MicroPython_BMPxxx/package.json to third-party
Copying: third-party/micropython_bmpxxx/__init__.py
Copying: third-party/micropython_bmpxxx/bmpxxx.py
Copying: third-party/micropython_bmpxxx/i2c_helpers.py
Done
```

